### PR TITLE
Accept TextIO at load_yaml and dump_yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,18 @@ pip install "compose-py[dataclasses]"
 ```py
 import compose_py
 
-obj = compose_py.load_yaml("docker-compose.yml")
+with open("docker-compose.yml", "r") as f:
+    obj = compose_py.load_yaml(f)
 print(obj)  # Prints 'compose_py.models_pydantic.ComposeSpecification(...)'
 print(obj.services["web"])  # Prints 'compose_py.models_pydantic.Service(...)'
 
 # Copy and modify the existing service, then add it to the specification
 web2 = obj.services["web"].copy()
-web2.command = '--port 8081'
+web2.command = "--port 8081"
 obj.services["web2"] = web2
 
-compose_py.dump_yaml(obj, "docker-compose-modified.yml")
+with open("docker-compose-modified.yml", "w") as f:
+    compose_py.dump_yaml(obj, f)
 ```
 
 You can find more APIs under `compose_py.models_pydantic` package.
@@ -45,16 +47,18 @@ You can find more APIs under `compose_py.models_pydantic` package.
 ```py
 import compose_py
 
-obj = compose_py.load_yaml("docker-compose.yml", model=compose_py.ModelType.DATACLASSES)
+with open("docker-compose.yml", "r") as f:
+    obj = compose_py.load_yaml(f, model=compose_py.ModelType.DATACLASSES)
 print(obj)  # Prints 'compose_py.models_dataclasses.ComposeSpecification(...)'
 print(obj.services["web"])  # Prints 'compose_py.models_dataclasses.Service(...)'
 
 # Copy and modify the existing service, then add it to the specification
 web2 = obj.services["web"].copy()
-web2.command = '--port 8081'
+web2.command = "--port 8081"
 obj.services["web2"] = web2
 
-compose_py.dump_yaml(obj, "docker-compose-modified.yml", model=compose_py.ModelType.DATACLASSES)
+with open("docker-compose-modified.yml", "w") as f:
+    compose_py.dump_yaml(obj, f, model=compose_py.ModelType.DATACLASSES)
 ```
 
 You can find more APIs under `compose_py.models_dataclasses` package.

--- a/compose_py/_yaml.py
+++ b/compose_py/_yaml.py
@@ -1,10 +1,7 @@
-import pathlib
 import typing
-from typing import Any, Dict, Optional, Type, Union
+from typing import Any, Dict, Optional, TextIO, Type, Union
 
 import yaml
-
-from ._types import Path
 
 DumperType = Any
 
@@ -19,29 +16,21 @@ else:
     LoaderType = Any
 
 
-def ensure_pathlib_obj(p: Path) -> pathlib.Path:
-    return pathlib.Path(p)
-
-
 def load(
-    path: Path,
+    stream: TextIO,
     *,
     loader: Optional[LoaderType] = None,
 ) -> Dict[str, Any]:
-    path = ensure_pathlib_obj(path)
     loader = loader or yaml.SafeLoader
-    with path.open("r") as f:
-        data: Dict[str, Any] = yaml.load(f, Loader=loader)
-        return data
+    data: Dict[str, Any] = yaml.load(stream, Loader=loader)
+    return data
 
 
 def dump(
     obj: Any,
-    path: Path,
+    stream: TextIO,
     *,
     dumper: Optional[DumperType] = None,
 ) -> None:
-    path = ensure_pathlib_obj(path)
     dumper = dumper or yaml.SafeDumper
-    with path.open("w") as f:
-        yaml.dump(obj, f, Dumper=dumper)
+    yaml.dump(obj, stream, Dumper=dumper)

--- a/compose_py/dumper.py
+++ b/compose_py/dumper.py
@@ -1,9 +1,8 @@
 import enum
 import typing
-from typing import Any, Dict, Optional, TypeVar, cast, overload
+from typing import Any, Dict, Optional, TextIO, TypeVar, cast, overload
 
 from . import _yaml
-from ._types import Path
 from .model_type import ModelType
 
 ComposeSpecification = Any
@@ -59,7 +58,7 @@ def dump_dict(
 @overload
 def dump_yaml(
     obj: "models_pydantic.ComposeSpecification",
-    path: Path,
+    stream: TextIO,
     *,
     model: "Literal[ModelType.PYDANTIC]" = ...,
     simplify: bool = ...,
@@ -71,7 +70,7 @@ def dump_yaml(
 @overload
 def dump_yaml(
     obj: "models_dataclasses.ComposeSpecification",
-    path: Path,
+    stream: TextIO,
     *,
     model: "Literal[ModelType.DATACLASSES]",
     simplify: bool = ...,
@@ -83,7 +82,7 @@ def dump_yaml(
 @overload
 def dump_yaml(
     obj: ComposeSpecification,
-    path: Path,
+    stream: TextIO,
     *,
     model: ModelType,
     simplify: bool = ...,
@@ -94,7 +93,7 @@ def dump_yaml(
 
 def dump_yaml(
     obj: ComposeSpecification,
-    path: Path,
+    stream: TextIO,
     *,
     model: ModelType = ModelType.PYDANTIC,
     simplify: bool = True,
@@ -102,7 +101,7 @@ def dump_yaml(
 ) -> None:
     data = dump_dict(obj, model=model, simplify=simplify)
     data = replace_enum_with_values(data)
-    _yaml.dump(data, path, dumper=dumper)
+    _yaml.dump(data, stream, dumper=dumper)
 
 
 def replace_enum_with_values(obj: TObj) -> TObj:

--- a/compose_py/loader.py
+++ b/compose_py/loader.py
@@ -1,8 +1,7 @@
 import typing
-from typing import Any, Dict, Optional, overload
+from typing import Any, Dict, Optional, TextIO, overload
 
 from . import _yaml
-from ._types import Path
 from .model_type import ModelType
 
 ComposeSpecification = Any
@@ -53,7 +52,7 @@ def load_dict(
 
 @overload
 def load_yaml(
-    path: Path,
+    stream: TextIO,
     *,
     model: "Literal[ModelType.PYDANTIC]" = ...,
     loader: Optional[_yaml.LoaderType] = ...,
@@ -63,7 +62,7 @@ def load_yaml(
 
 @overload
 def load_yaml(
-    path: Path,
+    stream: TextIO,
     *,
     model: "Literal[ModelType.DATACLASSES]",
     loader: Optional[_yaml.LoaderType] = ...,
@@ -73,7 +72,7 @@ def load_yaml(
 
 @overload
 def load_yaml(
-    path: Path,
+    stream: TextIO,
     *,
     model: ModelType,
     loader: Optional[_yaml.LoaderType] = ...,
@@ -82,10 +81,10 @@ def load_yaml(
 
 
 def load_yaml(
-    path: Path,
+    stream: TextIO,
     *,
     model: ModelType = ModelType.PYDANTIC,
     loader: Optional[_yaml.LoaderType] = None,
 ) -> ComposeSpecification:
-    data = _yaml.load(path, loader=loader)
+    data = _yaml.load(stream, loader=loader)
     return load_dict(data, model=model)

--- a/tests/compose_py_tests/test__yaml.py
+++ b/tests/compose_py_tests/test__yaml.py
@@ -4,10 +4,12 @@ from compose_py import _yaml
 
 
 def test_load(simple_yml: pathlib.Path, anchor_yml: pathlib.Path) -> None:
-    simple = _yaml.load(simple_yml)
+    with simple_yml.open("r") as f:
+        simple = _yaml.load(f)
     assert simple["services"]["web"]["ports"] == ["8000:5000"]
 
-    anchor = _yaml.load(anchor_yml)
+    with anchor_yml.open("r") as f:
+        anchor = _yaml.load(f)
     assert anchor["services"]["web"]["ports"] == ["8000:5000"]
 
     # Check anchor references are resolved at `load`

--- a/tests/compose_py_tests/test_loader.py
+++ b/tests/compose_py_tests/test_loader.py
@@ -6,7 +6,8 @@ from compose_py.model_type import ModelType
 
 
 def test_load_yaml_pydantic(simple_yml: pathlib.Path) -> None:
-    data_pydantic = load_yaml(simple_yml, model=ModelType.PYDANTIC)
+    with simple_yml.open("r") as f:
+        data_pydantic = load_yaml(f, model=ModelType.PYDANTIC)
     assert isinstance(data_pydantic, models_pydantic.ComposeSpecification)
     services = data_pydantic.services
     assert services is not None
@@ -19,7 +20,8 @@ def test_load_yaml_pydantic(simple_yml: pathlib.Path) -> None:
 
 
 def test_load_yaml_dataclasses(simple_yml: pathlib.Path) -> None:
-    data_dataclasses = load_yaml(simple_yml, model=ModelType.DATACLASSES)
+    with simple_yml.open("r") as f:
+        data_dataclasses = load_yaml(f, model=ModelType.DATACLASSES)
     assert isinstance(data_dataclasses, models_dataclasses.ComposeSpecification)
     services = data_dataclasses.services
     assert services is not None


### PR DESCRIPTION
Changed load_yaml and dump_yaml to accept any Text streams so that we can use the APIs with `StringIO`.

This PR contains breaking changes.